### PR TITLE
Make addaudio command loop video

### DIFF
--- a/improcessing.py
+++ b/improcessing.py
@@ -920,7 +920,7 @@ async def imageaudio(files):
     image = files[0]
     outname = temp_file("mp4")
     duration = await get_duration(audio)  # it is a couple seconds too long without it :(
-    await run_command("ffmpeg", "-hide_banner", "-i", audio, "-loop", "1", "-i", image, "-vf",
+    await run_command("ffmpeg", "-hide_banner", "-i", audio, "-loop", "-1", "-i", image, "-vf",
                       "crop=trunc(iw/2)*2:trunc(ih/2)*2", "-c:v", "libx264", "-c:a", "copy", "-shortest", "-t",
                       str(duration), outname)
     return outname

--- a/improcessing.py
+++ b/improcessing.py
@@ -920,13 +920,13 @@ async def imageaudio(files):
     image = files[0]
     outname = temp_file("mp4")
     duration = await get_duration(audio)  # it is a couple seconds too long without it :(
-    await run_command("ffmpeg", "-hide_banner", "-i", audio, "-loop", "-1", "-i", image, "-vf",
+    await run_command("ffmpeg", "-hide_banner", "-i", audio, "-loop", "1", "-i", image, "-vf",
                       "crop=trunc(iw/2)*2:trunc(ih/2)*2", "-c:v", "libx264", "-c:a", "copy", "-shortest", "-t",
-                      str(duration), outname)
+                       str(duration), outname)
     return outname
 
 
-async def addaudio(files):
+async def addaudio(files, loops):
     """
     adds audio to media
     :param files: [media, audiotoadd]
@@ -939,6 +939,20 @@ async def addaudio(files):
     if mt == "IMAGE":
         # no use reinventing the wheel
         return await imageaudio(files)
+    elif mt == "GIF":
+        # GIF case is like imageaudio, but with stream_loop instead of loop.
+        outname = temp_file("mp4")
+        if loops >= 0:
+            # if the gif is set to loop a fixed amount of times, cut out at the longest stream.
+            await run_command("ffmpeg", "-hide_banner", "-i", audio, "-stream_loop", str(loops), "-i", media, "-vf",
+                              "crop=trunc(iw/2)*2:trunc(ih/2)*2", "-c:v", "libx264", "-c:a", "copy", outname)
+        else:
+            # if it's set to loop infinitely, cut out when the audio ends.
+            duration = await get_duration(audio)  # it is a couple seconds too long without it :(
+            await run_command("ffmpeg", "-hide_banner", "-i", audio, "-stream_loop", str(loops), "-i", media, "-vf",
+                              "crop=trunc(iw/2)*2:trunc(ih/2)*2", "-c:v", "libx264", "-c:a", "copy", "-shortest", "-t",
+                               str(duration), outname)
+        return outname
     else:
         media = await forceaudio(media)
         # yes, qa works backwards on aac vs mp3. no, i dont know why.

--- a/improcessing.py
+++ b/improcessing.py
@@ -926,7 +926,7 @@ async def imageaudio(files):
     return outname
 
 
-async def addaudio(files, loops):
+async def addaudio(files, loops = 0):
     """
     adds audio to media
     :param files: [media, audiotoadd]

--- a/main.py
+++ b/main.py
@@ -852,15 +852,16 @@ if __name__ == "__main__":  # prevents multiprocessing workers from running bot 
             await improcess(ctx, improcessing.allreencode, [["VIDEO", "IMAGE", "AUDIO"]])
 
         @commands.command(aliases=["audioadd", "dub"])
-        async def addaudio(self, ctx):
+        async def addaudio(self, ctx, loops: number_range(-1, 100, num_type='int') = -1):
             """
             Adds audio to media.
 
             :param ctx: discord context
+            :param loops: Amount of times to loop a gif. -1 loops infinitely, 0 only once. Must be between -1 and 100.
             :mediaparam media: Any valid media file.
             :mediaparam audio: An audio file.
             """
-            await improcess(ctx, improcessing.addaudio, [["IMAGE", "GIF", "VIDEO", "AUDIO"], ["AUDIO"]])
+            await improcess(ctx, improcessing.addaudio, [["IMAGE", "GIF", "VIDEO", "AUDIO"], ["AUDIO"]], loops)
 
         @commands.command()
         async def jpeg(self, ctx, strength: number_range(0, 100, False, True, 'int') = 30,


### PR DESCRIPTION
The current behavior only plays the video/gif once in the mp4 output, which is usually not the desired behavior.
Setting the loops to -1 in ffmpeg should loop the video until the end.