### PR TITLE
Fix corrupted addaudio video output

### DIFF
--- a/improcessing.py
+++ b/improcessing.py
@@ -912,7 +912,7 @@ async def videoloop(file, loop):
 
 async def imageaudio(files):
     """
-    combines an image an an audio file into a video
+    combines an image and an audio file into a video
     :param files: [image, audio]
     :return: video
     """
@@ -920,7 +920,7 @@ async def imageaudio(files):
     image = files[0]
     outname = temp_file("mp4")
     duration = await get_duration(audio)  # it is a couple seconds too long without it :(
-    await run_command("ffmpeg", "-hide_banner", "-i", audio, "-loop", "1", "-i", image, "-vf",
+    await run_command("ffmpeg", "-hide_banner", "-i", audio, "-loop", "1", "-i", image, "-pix_fmt", "yuv420p", "-vf",
                       "crop=trunc(iw/2)*2:trunc(ih/2)*2", "-c:v", "libx264", "-c:a", "copy", "-shortest", "-t",
                        str(duration), outname)
     return outname
@@ -944,12 +944,12 @@ async def addaudio(files, loops = 0):
         outname = temp_file("mp4")
         if loops >= 0:
             # if the gif is set to loop a fixed amount of times, cut out at the longest stream.
-            await run_command("ffmpeg", "-hide_banner", "-i", audio, "-stream_loop", str(loops), "-i", media, "-vf",
+            await run_command("ffmpeg", "-hide_banner", "-i", audio, "-stream_loop", str(loops), "-i", media, "-pix_fmt", "yuv420p", "-vf",
                               "crop=trunc(iw/2)*2:trunc(ih/2)*2", "-c:v", "libx264", "-c:a", "copy", outname)
         else:
             # if it's set to loop infinitely, cut out when the audio ends.
             duration = await get_duration(audio)  # it is a couple seconds too long without it :(
-            await run_command("ffmpeg", "-hide_banner", "-i", audio, "-stream_loop", str(loops), "-i", media, "-vf",
+            await run_command("ffmpeg", "-hide_banner", "-i", audio, "-stream_loop", str(loops), "-i", media, "-pix_fmt", "yuv420p", "-vf",
                               "crop=trunc(iw/2)*2:trunc(ih/2)*2", "-c:v", "libx264", "-c:a", "copy", "-shortest", "-t",
                                str(duration), outname)
         return outname


### PR DESCRIPTION
hi hello welcome to another pr from me

The addaudio command was generating corrupted video files when used with images and gifs - this wasn't that big of a deal because on Windows it just displayed a broken or no thumbnail while the video itself was fine. However, on mobile these videos look like a garbled mess when played.

Forcing the pixel format of the output videos to 4:2:0 fixes these issues.