### PR TITLE
Don't use ``delete_after`` attribute if ``msg`` is ``WebhookMessage``

### DIFF
--- a/src/processing/ffmpeg.py
+++ b/src/processing/ffmpeg.py
@@ -12,7 +12,7 @@ from processing.ffprobe import *
 from utils.tempfiles import TempFile
 
 
-async def ensureduration(media, ctx: typing.Union[commands.Context, None]):
+async def ensureduration(media, ctx: typing.Union[commands.Context, discord.WebhookMessage, None]):
     """
     ensures that media is under or equal to the config minimum frame count and fps
     :param media: media to trim
@@ -49,7 +49,10 @@ async def ensureduration(media, ctx: typing.Union[commands.Context, None]):
             msg = await ctx.reply(tmsg)
         media = await trim(media, newdur)
         if ctx is not None:
-            await msg.edit(content=tmsg + " Done!", delete_after=5)
+            if isinstance(ctx, discord.WebhookMessage):
+                await msg.edit(content=tmsg + " Done!")  # WebhookMessage doesn't have a delete_after attribute!
+            else:
+                await msg.edit(content=tmsg + " Done!", delete_after=5)
         return media
 
 


### PR DESCRIPTION
The bot gave me an error while I was using it and I was like "oh wait I think I see the fix!" This should be the fix.

 I am currently unable to validate that this code is functioning, but it _should_ work.